### PR TITLE
Fix links to QuickJS website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SlimJS
 
-SlimJS is a (**very much WIP**) lightweight Javascript engine written in `Rust` and ported from [QuickJS](bellard.org/quickjs/). 
+SlimJS is a (**very much WIP**) lightweight Javascript engine written in `Rust` and ported from [QuickJS](https://bellard.org/quickjs/). 
 
 ## Origins
 
-The codebase was ported from [QuickJS](bellard.org/quickjs/), a `C` Javascript runtime written by Fabrice Bellard and Charlie Gordon.
+The codebase was ported from [QuickJS](https://bellard.org/quickjs/), a `C` Javascript runtime written by Fabrice Bellard and Charlie Gordon.
 
 Right now the code looks much more like C than idiomatic Rust,
 but will be incrementally rewritten to benefit from the added safety and better maintainability that Rust provides.


### PR DESCRIPTION
The links in the README were not actually pointing to the website so I fixed it. 

Also the repository description reads:

> Public repository of the QuickJS Javascript Engine. Pull requests are not accepted. Use the mailing list to submit patches. 

Which might discourage people from contributing. If I understand correctly QuickJS doesn't accept pull requests while slimjs does?